### PR TITLE
Fix NETCONF Action marshaling

### DIFF
--- a/netconf/message/action.go
+++ b/netconf/message/action.go
@@ -19,13 +19,15 @@ package message
 // Action represents the NETCONF `action` message.
 type Action struct {
 	RPC
-	Action interface{} `xml:"action"`
+	Action struct {
+		Data interface{} `xml:",innerxml"`
+	} `xml:"urn:ietf:params:xml:ns:yang:1 action"`
 }
 
 // NewAction can be used to create an `action` message.
 func NewAction(msg string) *Action {
 	var rpc Action
-	rpc.Action = msg
+	rpc.Action.Data = msg
 	rpc.MessageID = uuid()
 	return &rpc
 }

--- a/tests/message_test.go
+++ b/tests/message_test.go
@@ -314,10 +314,10 @@ func TestNewDiscardChanges(t *testing.T) {
 }
 
 func TestNewAction(t *testing.T) {
-	discardMsg := "some action message"
-	expected := "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"\"><action>" + discardMsg + "</action></rpc>"
+	actionMsg := "<some>message</some>"
+	expected := "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"\"><action xmlns=\"urn:ietf:params:xml:ns:yang:1\">" + actionMsg + "</action></rpc>"
 
-	rpc := message.NewAction(discardMsg)
+	rpc := message.NewAction(actionMsg)
 	output, err := xml.Marshal(rpc)
 	if err != nil {
 		t.Errorf(err.Error())


### PR DESCRIPTION
Unfortunately the current implementation did not properly decode special characters such as `<` and `>`, which resulted in a garbled action message being sent to the NETCONF server.

If you add a `<` character to the existing test case for `Action`:
```
=== RUN   TestNewAction
    /home/hansu/vitrifi/go-netconf-client/tests/message_test.go:327: TestNewAction:
        Got:<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id=""><action>&lt;some action message</action></rpc>
        Want:
        <rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id=""><action><some action message</action></rpc>
--- FAIL: TestNewAction (0.00s)
FAIL
FAIL    github.com/vitrifi/go-netconf-client/tests      0.002
```

This MR fixes it, not sure if there is a better way to address it.