### PR TITLE
Add confirmed commit features

### DIFF
--- a/examples/test-rpc.go
+++ b/examples/test-rpc.go
@@ -90,7 +90,11 @@ func execRPC(session *netconf.Session) {
 	time.Sleep(100 * time.Millisecond)
 
 	// Commit
-	c := message.NewCommit("")
+	const (
+		confirmed      = false
+		confirmTimeout = 0
+	)
+	c := message.NewCommit(confirmed, confirmTimeout)
 	session.AsyncRPC(c, defaultLogRPCReplyCallback(c.MessageID))
 	time.Sleep(100 * time.Millisecond)
 

--- a/netconf/message/cancel-commit.go
+++ b/netconf/message/cancel-commit.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2025. Hannu Kamarainen
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package message
+
+// CancelCommit represents the NETCONF `cancel-commit` message.
+// https://datatracker.ietf.org/doc/html/rfc6241#section-8.4.4.1
+type CancelCommit struct {
+	RPC
+	CancelCommit struct{} `xml:"cancel-commit"`
+}
+
+// NewCancelCommit can be used to create a `cancel-commit` message.
+//
+// Example cancel-commit message:
+// <rpc message-id="102" xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+// ..<cancel-commit/>
+// </rpc>
+func NewCancelCommit() *CancelCommit {
+	var rpc CancelCommit
+	rpc.MessageID = uuid()
+	return &rpc
+}

--- a/netconf/message/commit.go
+++ b/netconf/message/commit.go
@@ -20,13 +20,45 @@ package message
 // https://datatracker.ietf.org/doc/html/rfc6241#section-8.3.4.1
 type Commit struct {
 	RPC
-	Commit interface{} `xml:"commit"`
+	Commit commit `xml:"commit"`
+}
+
+type commit struct {
+	XMLName        string  `xml:"commit"`
+	Confirmed      *string `xml:"confirmed,omitempty"`
+	ConfirmTimeout *int    `xml:"confirm-timeout,omitempty"`
 }
 
 // NewCommit can be used to create a `commit` message.
-func NewCommit(msg string) *Commit {
+//
+// Example commit message:
+// <rpc message-id="101">
+// ..<commit></commit>
+// </rpc>
+//
+// Example commit-confirmed message:
+// <rpc message-id="101">
+// ..<commit>
+// ....<confirmed/>
+// ..</commit>
+// </rpc>
+//
+// Example commit-confirmed message with custom timeout (seconds):
+// <rpc message-id="101">
+// ..<commit>
+// ....<confirmed/>
+// ....<confirm-timeout>120</confirm-timeout>
+// ..</commit>
+// </rpc>
+func NewCommit(confirmed bool, confirmTimeout int) *Commit {
 	var rpc Commit
-	rpc.Commit = msg
+	if confirmed {
+		s := ""
+		rpc.Commit.Confirmed = &s
+	}
+	if confirmTimeout > 0 {
+		rpc.Commit.ConfirmTimeout = &confirmTimeout
+	}
 	rpc.MessageID = uuid()
 	return &rpc
 }

--- a/netconf/message/discard-changes.go
+++ b/netconf/message/discard-changes.go
@@ -20,13 +20,12 @@ package message
 // https://datatracker.ietf.org/doc/html/rfc6241#section-8.3.4.2
 type DiscardChanges struct {
 	RPC
-	DiscardChanges interface{} `xml:"discard-changes"`
+	DiscardChanges struct{} `xml:"discard-changes"`
 }
 
 // NewDiscardChanges can be used to create a `discard-changes` message.
-func NewDiscardChanges(msg string) *DiscardChanges {
+func NewDiscardChanges() *DiscardChanges {
 	var rpc DiscardChanges
-	rpc.DiscardChanges = msg
 	rpc.MessageID = uuid()
 	return &rpc
 }

--- a/tests/message_test.go
+++ b/tests/message_test.go
@@ -299,10 +299,9 @@ func TestNewCommit(t *testing.T) {
 }
 
 func TestNewDiscardChanges(t *testing.T) {
-	discardMsg := "some discard changes message"
-	expected := "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"\"><discard-changes>" + discardMsg + "</discard-changes></rpc>"
+	expected := "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"\"><discard-changes></discard-changes></rpc>"
 
-	rpc := message.NewDiscardChanges(discardMsg)
+	rpc := message.NewDiscardChanges()
 	output, err := xml.Marshal(rpc)
 	if err != nil {
 		t.Errorf(err.Error())

--- a/tests/message_test.go
+++ b/tests/message_test.go
@@ -284,17 +284,71 @@ func TestNewEstablishSubscription(t *testing.T) {
 }
 
 func TestNewCommit(t *testing.T) {
-	commitMsg := "some commit message"
-	expected := "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"\"><commit>" + commitMsg + "</commit></rpc>"
+	type args struct {
+		expected       string
+		confirmed      bool
+		confirmTimeout int
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "normal commit",
+			args: args{
+				expected: "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"\"><commit></commit></rpc>",
+			},
+		},
+		{
+			name: "confirmed-commit",
+			args: args{
+				expected:  "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"\"><commit><confirmed></confirmed></commit></rpc>",
+				confirmed: true,
+			},
+		},
+		{
+			name: "confirm-timeout",
+			args: args{
+				expected:       "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"\"><commit><confirm-timeout>120</confirm-timeout></commit></rpc>",
+				confirmTimeout: 120,
+			},
+		},
+		{
+			name: "confirmed-commit and confirm-timeout",
+			args: args{
+				expected:       "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"\"><commit><confirmed></confirmed><confirm-timeout>120</confirm-timeout></commit></rpc>",
+				confirmed:      true,
+				confirmTimeout: 120,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 
-	rpc := message.NewCommit(commitMsg)
+			rpc := message.NewCommit(tt.args.confirmed, tt.args.confirmTimeout)
+			output, err := xml.Marshal(rpc)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			if got, want := StripUUID(string(output)), StripUUID(tt.args.expected); got != want {
+				t.Errorf("TestNewCommit:\nGot:%s\nWant:\n%s", got, want)
+			}
+		})
+	}
+}
+
+func TestNewCancelCommit(t *testing.T) {
+	expected := "<rpc xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\" message-id=\"\"><cancel-commit></cancel-commit></rpc>"
+
+	rpc := message.NewCancelCommit()
 	output, err := xml.Marshal(rpc)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
 	if got, want := StripUUID(string(output)), StripUUID(expected); got != want {
-		t.Errorf("TestNewCommit:\nGot:%s\nWant:\n%s", got, want)
+		t.Errorf("TestNewCancelCommit:\nGot:%s\nWant:\n%s", got, want)
 	}
 }
 


### PR DESCRIPTION
- Add new parameters to Commit, related to confirmed-commit https://datatracker.ietf.org/doc/html/rfc6241#section-8.4
- Remove previously existing commit message parameter, because it is not actually part of the RFC (only available through extensions/customizations and thus largely vendor dependant)
- Likewise remove discard-changes message

The example XML messages have dots instead of spaces because vscode insisted on formatting the messages in a really messed-up way every time the file is saved.